### PR TITLE
Retire oaDOI name

### DIFF
--- a/static/src/landing.tpl.html
+++ b/static/src/landing.tpl.html
@@ -12,9 +12,9 @@
             <div class="about">
                 Impactstory is a nonprofit obsessed with making scholarly research more
                 open, accessible, and reusable. We create and support free services including
-                <a href="http://unpaywall.org">Unpaywall,</a>
-                <a href="http://oadoi.org">oaDOI,</a>
-                <a href="http://profiles.impactstory.org">Impactstory Profiles,</a> and
+                <a href="https://unpaywall.org">Unpaywall,</a>
+                <a href="https://unpaywall.org/data">Unpaywall data,</a>
+                <a href="https://profiles.impactstory.org">Impactstory Profiles,</a> and
                 <a href="http://depsy.org">Depsy.</a>
             </div>
             <div class="links">


### PR DESCRIPTION
I noticed http://impactstory.org/ still referred to oaDOI, so I figured I'd make a PR with the updated name.

I also changed links to your other projects to HTTPS, if possible.